### PR TITLE
feature: define variables within define syntax

### DIFF
--- a/rs/src/parser.rs
+++ b/rs/src/parser.rs
@@ -603,6 +603,20 @@ mod tests {
         assert_eq!(exp, x);
         assert_eq!(ok(vec![exp]), program(prog));
 
+        let prog = "(define pi 42)";
+        let exp = Lambda(Code {
+            name: Some(Ident::new("pi")),
+            tail: false,
+            formals: vec![],
+            body: vec![42.into()],
+            free: vec![],
+        });
+
+        let (rest, x) = super::define_syntax(prog)?;
+        assert_eq!(rest, "");
+        assert_eq!(exp, x);
+        assert_eq!(ok(vec![exp]), program(prog));
+
         let prog = "(define (add a b) (+ a b))";
         let exp = Lambda(Code {
             name: Some(Ident::new("add")),


### PR DESCRIPTION
Changes:

1. define_syntax -> split into define_lambda and define_variable
2. added test for define variable